### PR TITLE
xcode 6.3.1 build error when building for device

### DIFF
--- a/gem/lib/illuminator/automation-builder.rb
+++ b/gem/lib/illuminator/automation-builder.rb
@@ -27,7 +27,7 @@ module Illuminator
         @arch = @arch || 'i386'
       else
         @sdk = sdk || 'iphoneos'
-        @arch = @arch || 'armv7'
+        #@arch = @arch || 'armv7'
         @destination = "id=#{hardwareID}"
         preprocessorDefinitions += " AUTOMATION_UDID=#{hardwareID}"
       end


### PR DESCRIPTION
When building for the device with Xcode 6.3.1, Build version 6D1002, the build errors out due to xcodebuild: error: -destination implies architecture, -arch must not also be specified. I just commented out the arch and it built fine.  Did not test with older xcodes since I already saw 5 was marked for deprecation and that was the only other xcode I had.