### PR TITLE
Don't specify compiler arch when the target is a real device

### DIFF
--- a/gem/lib/illuminator/automation-builder.rb
+++ b/gem/lib/illuminator/automation-builder.rb
@@ -27,7 +27,7 @@ module Illuminator
         @arch = @arch || 'i386'
       else
         @sdk = sdk || 'iphoneos'
-        @arch = @arch || 'armv7'
+        #@arch = @arch || 'armv7'
         @destination = "id=#{hardwareID}"
         preprocessorDefinitions += " AUTOMATION_UDID=#{hardwareID}"
       end

--- a/gem/lib/illuminator/automation-builder.rb
+++ b/gem/lib/illuminator/automation-builder.rb
@@ -27,7 +27,6 @@ module Illuminator
         @arch = @arch || 'i386'
       else
         @sdk = sdk || 'iphoneos'
-        #@arch = @arch || 'armv7'
         @destination = "id=#{hardwareID}"
         preprocessorDefinitions += " AUTOMATION_UDID=#{hardwareID}"
       end


### PR DESCRIPTION
Fixes #52 