### PR TITLE
Fix ruby error handling for instruments runner

### DIFF
--- a/gem/lib/illuminator/instruments-runner.rb
+++ b/gem/lib/illuminator/instruments-runner.rb
@@ -208,10 +208,7 @@ class InstrumentsRunner
           end
         end
 
-      rescue Errno::EIO
-      rescue Errno::ECHILD
-      rescue EOFError
-      rescue PTY::ChildExited
+      rescue Errno::EIO, Errno::ECHILD, EOFError, PTY::ChildExited
         STDERR.puts 'Instruments exited unexpectedly'
         if @fully_started
           successful_run = false


### PR DESCRIPTION
Should fix the bug where Illuminator occasionally hangs when starting instruments when running in Jenkins.