### PR TITLE
Test runner improvements

### DIFF
--- a/docs/Commandline.md
+++ b/docs/Commandline.md
@@ -94,6 +94,7 @@ options.simulator.kill_after = true
 
 options.instruments.do_verbose = false
 options.instruments.timeout = 30
+options.instruments.max_silence = nil  # defaults to timeout * 5
 
 options.javascript.test_path = all_test_path
 options.javascript.implementation = 'iPhone'
@@ -239,6 +240,8 @@ The number of seconds to spend waiting for Instruments to start up and begin exe
 The number of times to attempt starting and restarting Instruments before giving up.
 > Under Xcode 5, this number needed to be set as high as 30.  No joke.
 
+#### `options.instruments.max_silence` (integer)
+The number of seconds to spend waiting for Instruments to produce output, before simply killing it.  This will unstick instruments in cases where the iOS simulator is closed -- instruments will hang.
 
 #### `options.instruments.app_location` (string)
 The location of the compiled application that Instruments will automate.  This option should be specified if you are automating a pre-built binary; otherwise, Illuminator defaults to using the application that it built itself and will expect to find it in `options.build_artifacts_dir`.

--- a/gem/lib/illuminator/automation-runner.rb
+++ b/gem/lib/illuminator/automation-runner.rb
@@ -232,6 +232,44 @@ class AutomationRunner
   end
 
 
+  def configure_instruments_runner_listeners(options)
+    test_listener = TestListener.new
+    test_listener.event_sink = self
+    @instruments_runner.add_listener("test_listener", test_listener)
+
+    stop_detector = StopDetector.new
+    stop_detector.event_sink = self
+    @instruments_runner.add_listener("stop_detector", stop_detector)
+
+    # listener to provide screen output
+    if options.instruments.do_verbose
+      @instruments_runner.add_listener("consoleoutput", FullOutput.new)
+    else
+      @instruments_runner.add_listener("consoleoutput", PrettyOutput.new)
+    end
+  end
+
+  def configure_instruments_runner(options)
+    # set up instruments and get target device ID
+    @instruments_runner.startup_timeout = options.instruments.timeout
+    @instruments_runner.hardware_id     = options.illuminator.hardware_id
+    @instruments_runner.app_location    = @app_location
+
+    if options.illuminator.hardware_id.nil?
+      @instruments_runner.sim_language  = options.simulator.language
+      @instruments_runner.sim_device    = Illuminator::XcodeUtils.instance.get_simulator_id(options.simulator.device,
+                                                                                            options.simulator.version)
+    end
+
+    # max silence is the timeout times 5 unless otherwise specified
+    @instruments_runner.max_silence = options.instruments.max_silence
+    @instruments_runner.max_silence ||= options.instruments.timeout * 5
+
+    # setup listeners on instruments
+    configure_instruments_runner_listeners(options)
+  end
+
+
   def run_with_options(options)
     gcovr_workspace = Dir.pwd
 
@@ -242,42 +280,20 @@ class AutomationRunner
 
     @app_name        = options.xcode.app_name
     @app_location    = options.instruments.app_location
-    @implementation = options.javascript.implementation
+    @implementation  = options.javascript.implementation
 
     # set up instruments and get target device ID
-    @instruments_runner.startup_timeout = options.instruments.timeout
-    @instruments_runner.hardware_id     = options.illuminator.hardware_id
-    @instruments_runner.app_location    = @app_location
+    configure_instruments_runner(options)
     unless options.illuminator.hardware_id.nil?
       puts "Using hardware_id = '#{options.illuminator.hardware_id}' instead of simulator".green
       target_device_id = options.illuminator.hardware_id
     else
-      @instruments_runner.sim_language  = options.simulator.language
-      @instruments_runner.sim_device    = Illuminator::XcodeUtils.instance.get_simulator_id(options.simulator.device,
-                                                                                        options.simulator.version)
       if @instruments_runner.sim_device.nil?
         puts "Could not find a simulator for device='#{options.simulator.device}', version='#{options.simulator.version}'".red
         puts Illuminator::XcodeUtils.instance.get_simulator_devices.yellow
         return false
       end
       target_device_id = @instruments_runner.sim_device
-    end
-
-    # setup listeners on instruments
-    test_listener = TestListener.new
-    test_listener.event_sink = self
-    @instruments_runner.add_listener("test_listener", test_listener)
-
-    stop_detector = StopDetector.new
-    stop_detector.event_sink = self
-    @instruments_runner.add_listener("stop_detector", stop_detector)
-
-
-    # listener to provide screen output
-    if options.instruments.do_verbose
-      @instruments_runner.add_listener("consoleoutput", FullOutput.new)
-    else
-      @instruments_runner.add_listener("consoleoutput", PrettyOutput.new)
     end
 
     # reset the simulator if desired

--- a/gem/lib/illuminator/instruments-runner.rb
+++ b/gem/lib/illuminator/instruments-runner.rb
@@ -246,7 +246,7 @@ class InstrumentsRunner
               silence_duration += @startup_timeout  # (the amount of time we waited for a select)
               puts "Instruments seems to have started but has not produced output in #{@startup_timeout} seconds".yellow
               if @max_silence < silence_duration
-                @should_reset_everything = true
+                @should_abort = true
               end
             end
           end

--- a/gem/lib/illuminator/instruments-runner.rb
+++ b/gem/lib/illuminator/instruments-runner.rb
@@ -63,12 +63,13 @@ class InstrumentsRunner
   include IntermittentFailureDetectorEventSink
   include TraceErrorDetectorEventSink
 
-  attr_accessor :app_location
-  attr_accessor :hardware_id
-  attr_accessor :sim_device
-  attr_accessor :sim_language
-  attr_accessor :attempts
-  attr_accessor :startup_timeout
+  attr_accessor :app_location     # the app to run
+  attr_accessor :hardware_id      # hardware id specifier
+  attr_accessor :sim_device       # sim device id specifier
+  attr_accessor :sim_language     # sim language (unsupported currently)
+  attr_accessor :attempts         # number of times to try running instruments before giving up
+  attr_accessor :startup_timeout  # amount of time to wait for initial instruments output
+  attr_accessor :max_silence      # if instruments goes silent for this long, we kill it.
 
   attr_reader :started
 
@@ -208,6 +209,7 @@ class InstrumentsRunner
       # spawn process and catch unexpected exits
       begin
         PTY.spawn(*command) do |r, w, pid|
+          silence_duration = 0
 
           done_reading_output = false
           # select on the output and send it to the listeners
@@ -238,9 +240,14 @@ class InstrumentsRunner
               Illuminator::XcodeUtils.kill_all_simulator_processes @sim_device
               # TODO: might be necessary to delete any app crashes at this point
             else
-              # We failed to get output for @startuptTimeout, but that's probably OK since we've successfully started
-              # TODO: if we need to enforce a maximum time spent without output, this is where the counter would go
+              # We failed to get output for @startupTimeout, but that's probably OK since we've successfully started
+              # But we still enforce a maximum time spent without output
+
+              silence_duration += @startup_timeout  # (the amount of time we waited for a select)
               puts "Instruments seems to have started but has not produced output in #{@startup_timeout} seconds".yellow
+              if @max_silence < silence_duration
+                @should_reset_everything = true
+              end
             end
           end
         end

--- a/gem/lib/illuminator/listeners/trace-error-detector.rb
+++ b/gem/lib/illuminator/listeners/trace-error-detector.rb
@@ -20,8 +20,11 @@ class TraceErrorDetector < InstrumentsListener
   end
 
   def receive message
-    if message.full_line =~ /Instruments Trace Error : Target failed to run: Unable to install app with path:/
+    itr = "Instruments Trace Error : Target failed to run:"
+    if message.full_line =~ /#{itr} Unable to install app with path:/
       trigger(false, "Failed to install app because #{message.full_line.split(': ')[-1]}")
+    elsif message.full_line =~ /#{itr} The operation couldn’t be completed./
+      trigger(false, "An operation couldn't be completed because #{message.full_line.split(': ')[-1]}")
     elsif message.full_line =~ /Instruments Trace Error/i
       trigger(false, message.full_line.split(' : ')[1..-1].join)
     end

--- a/gem/lib/illuminator/options.rb
+++ b/gem/lib/illuminator/options.rb
@@ -83,6 +83,7 @@ module Illuminator
 
       self.instruments.do_verbose = nil
       self.instruments.timeout = nil
+      self.instruments.max_silence = nil
       self.instruments.attempts = nil
       self.instruments.app_location = nil  # normally, this is where we build to
 

--- a/gem/lib/illuminator/resources/IlluminatorGeneratedEnvironment.erb
+++ b/gem/lib/illuminator/resources/IlluminatorGeneratedEnvironment.erb
@@ -3,6 +3,10 @@
  * It provides global path information that would be problematic to introduce through config values
  *  (especially given that the config comes from a file)
  */
+
+// Based on the way UIAutomation processes imports, this will be the first line of code to actually execute
+UIALogger.logDebug("Illuminator has launched.");
+
 var IlluminatorRootDirectory = "<%= @illuminator_root %>";
 var IlluminatorScriptsDirectory = "<%= @illuminator_scripts %>";
 var IlluminatorBuildArtifactsDirectory = "<%= @artifacts_root %>";

--- a/gem/lib/illuminator/test-suite.rb
+++ b/gem/lib/illuminator/test-suite.rb
@@ -24,15 +24,11 @@ class TestSuite
   # TODO: fix naming, some of these return test cases and some return arrays of names
 
   def unstarted_tests
-    ret = Array.new
-    @test_cases.each { |t| ret << t.name unless t.ran? }
-    ret
+    @test_cases.reject { |t| t.ran? }.map { |t| t.name }
   end
 
   def finished_tests
-    ret = Array.new
-    @test_cases.each { |t| ret << t.name if t.ran? }
-    ret
+    @test_cases.select { |t| t.ran? } .map { |t| t.name }
   end
 
   def all_tests


### PR DESCRIPTION
Instruments appears to hang when the iOS simulator is closed.  This PR implements a long-considered timeout feature for instruments output, and exposes `options.instruments.max_silence` (default 5x the startup timeout) to deal with it.

Test scenarios that hit this timeout more than once will be considered error cases.