### PR TITLE
Enable UIATarget to tell you its language and locale settings

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -225,6 +225,12 @@ Returns true if the element is not `UIAElementNil`.
 #### `.isVisible()` - UIAElementNil
 Similar to `.isVisible()` for ordinary UIAElement objects but always returns false.  Provided for compatibility.
 
+#### `.language()` - UIATarget
+Return the device language that was specified to Illuminator on startup
+
+#### `.locale()` - UIATarget
+Return the device locale that was specified to Illuminator on startup
+
 #### `.openURL(url)` - UIATarget
 Open a URL on the target device.
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -43,6 +43,13 @@ config.targetDeviceID = "<one of the UIDs from 'simctl list'>";
 config.isHardware = false; // indicate that we are on a simulator
 ```
 
+Finally, the following optional variables may be provided to suppress warnings:
+
+```javascript
+config.targetDeviceLanguage = "< a language code >";  // e.g. "EN"
+config.targetDeviceLocale = "< a locale code >";      // e.g. "en_US"
+```
+
 
 Advanced Features: The [Bridge](Bridge.md)
 ------------------------------------------

--- a/gem/lib/illuminator/automation-runner.rb
+++ b/gem/lib/illuminator/automation-runner.rb
@@ -190,22 +190,24 @@ class AutomationRunner
   def configure_javascript_runner(options, target_device_id)
     js_config = @javascript_runner
 
-    js_config.target_device_id     = target_device_id
-    js_config.is_hardware          = !(options.illuminator.hardware_id.nil?)
-    js_config.implementation       = options.javascript.implementation
-    js_config.test_path            = options.javascript.test_path
+    js_config.target_device_id       = target_device_id
+    js_config.target_device_language = options.simulator.language
+    js_config.target_device_locale   = options.simulator.locale
+    js_config.is_hardware            = !(options.illuminator.hardware_id.nil?)
+    js_config.implementation         = options.javascript.implementation
+    js_config.test_path              = options.javascript.test_path
 
-    js_config.entry_point          = options.illuminator.entry_point
-    js_config.scenario_list        = options.illuminator.test.names
-    js_config.tags_any             = options.illuminator.test.tags.any
-    js_config.tags_all             = options.illuminator.test.tags.all
-    js_config.tags_none            = options.illuminator.test.tags.none
-    js_config.random_seed          = options.illuminator.test.random_seed
+    js_config.entry_point            = options.illuminator.entry_point
+    js_config.scenario_list          = options.illuminator.test.names
+    js_config.tags_any               = options.illuminator.test.tags.any
+    js_config.tags_all               = options.illuminator.test.tags.all
+    js_config.tags_none              = options.illuminator.test.tags.none
+    js_config.random_seed            = options.illuminator.test.random_seed
 
-    js_config.sim_device           = options.simulator.device
-    js_config.sim_version          = options.simulator.version
+    js_config.sim_device             = options.simulator.device
+    js_config.sim_version            = options.simulator.version
 
-    js_config.app_specific_config  = options.javascript.app_specific_config
+    js_config.app_specific_config    = options.javascript.app_specific_config
 
     # don't offset the numbers this time
     js_config.scenario_number_offset = 0

--- a/gem/lib/illuminator/javascript-runner.rb
+++ b/gem/lib/illuminator/javascript-runner.rb
@@ -14,6 +14,8 @@ class JavascriptRunner
 
   attr_reader   :saltinel # the salted sentinel
   attr_accessor :target_device_id
+  attr_accessor :target_device_language
+  attr_accessor :target_device_locale
   attr_accessor :is_hardware
   attr_accessor :entry_point
   attr_accessor :test_path
@@ -47,6 +49,8 @@ class JavascriptRunner
       'automatorDesiredSimDevice'    => @sim_device,
       'automatorDesiredSimVersion'   => @sim_version,
       'targetDeviceID'               => @target_device_id,
+      'targetDeviceLanguage'         => @target_device_language,
+      'targetDeviceLocale'           => @target_device_locale,
       'isHardware'                   => @is_hardware,
       'xcodePath'                    => Illuminator::XcodeUtils.instance.get_xcode_path,
       'automatorSequenceRandomSeed'  => @random_seed,

--- a/gem/resources/js/Config.js
+++ b/gem/resources/js/Config.js
@@ -40,6 +40,8 @@
         "automatorDesiredSimDevice": true,
         "automatorDesiredSimVersion": true,
         "targetDeviceID": true,
+        "targetDeviceLanguage": false,
+        "targetDeviceLocale": false,
         "isHardware": true,
         "xcodePath": true,
         "automatorTagsAny": false,

--- a/gem/resources/js/Config.js
+++ b/gem/resources/js/Config.js
@@ -86,8 +86,8 @@
     config.buildArtifacts.automatorJSON         = tmpDir + "/automator.json";
     config.buildArtifacts.automatorScenarioJSON = tmpDir + "/automatorScenarios.json";
     config.buildArtifacts.intendedTestList      = tmpDir + "/intendedTestList.json";
-    
-    //This line is a placeholder so that the automator can communicate its current operation to the entire set of Illuminator javascript extensions. 
+
+    //This line is a placeholder so that the automator can communicate its current operation to the entire set of Illuminator javascript extensions.
     //This is because the logical first choice for implementing this -- automator state -- is not available from Extensions.js
     config.automatorModality                    = "init";
 

--- a/gem/resources/js/Extensions.js
+++ b/gem/resources/js/Extensions.js
@@ -1739,6 +1739,20 @@ extendPrototype(UIATarget, {
     },
 
     /**
+     * Get the target device language
+     */
+    language: function () {
+        return config.targetDeviceLanguage;
+    },
+
+    /**
+     * Get the target device locale
+     */
+    locale: function () {
+        return config.targetDeviceLocale;
+    },
+
+    /**
      * Open a URL on the target device
      *
      * @param url string the URL


### PR DESCRIPTION
In combination with #83, this patch gives the javascript environment access to the sim's language and locale.  They can be accessed directly from `config. targetDeviceLanguage` and `config. targetDeviceLocale`. 

However, the sensible way to access them is via the new methods on `UIATarget`: `target().language()` and `target().locale()`.