### PR TITLE
Allow custom result handler function in IlluminatorTestProgress.finish()

### DIFF
--- a/Example/IlluminatorUITests/AppDefinition/ExampleTestApp.swift
+++ b/Example/IlluminatorUITests/AppDefinition/ExampleTestApp.swift
@@ -21,8 +21,11 @@ import Illuminator
 // Actions can both read and write the state object, or ignore it completely
 //
 // In this example, we just use a simple (named) boolean flag.
-struct AppTestState {
-  var didSomething: Bool
+struct AppTestState: CustomStringConvertible {
+    var didSomething: Bool
+    var description: String {
+        get { return "\(didSomething)" }
+    }
 }
 
 

--- a/Example/IlluminatorUITests/AppDefinition/Screens/HomeScreen.swift
+++ b/Example/IlluminatorUITests/AppDefinition/Screens/HomeScreen.swift
@@ -28,14 +28,21 @@ class HomeScreen: IlluminatorDelayedScreen<AppTestState> {
             textField.typeText(what)
         }
     }
-    
+
     func verifyText(expected: String) -> IlluminatorActionGeneric<AppTestState> {
         return makeAction() {
             let textField = self.app.otherElements.containingType(.Button, identifier:"Button").childrenMatchingType(.TextField).element
             XCTAssertEqual(textField.value as? String, expected)
         }
-        }
     }
-    
+
+    func enterAndVerifyText(what: String) -> IlluminatorActionGeneric<AppTestState> {
+        return makeAction([
+            enterText(what),
+            verifyText(what)
+            ])
+    }
+}
+
 
 

--- a/Example/IlluminatorUITests/IlluminatorUITests.swift
+++ b/Example/IlluminatorUITests/IlluminatorUITests.swift
@@ -14,16 +14,17 @@ class IlluminatorUITests: XCTestCase, IlluminatorTestResultHandler {
     
     // implement IlluminatorTestResultHandler protocol
     typealias AbstractStateType = AppTestState
-    func handleTestResult(isPass: Bool, isFail: Bool, state: AbstractStateType?, errorMessages: [String]) -> (){
-        // on failure, print out what was on the screen when things failed
-        if isFail {
+    func handleTestResult(progress: IlluminatorTestProgress<AbstractStateType>) -> (){
+
+        switch progress {
+        case .Failing(let state):
+            print("Failing state was \(state)")
+            // on failure, print out what was on the screen when things failed
             for line in IlluminatorElement.accessorDump("app", appDebugDescription: app.debugDescription) {
                 print(line)
             }
-        }
-        
-        if isPass {
-            print("THE RESULT WAS A PASS! but generally we don't do anything for passing tests")
+         default:
+            () // do nothing, fall back on default implementation of finish()
         }
     }
     

--- a/Example/IlluminatorUITests/IlluminatorUITests.swift
+++ b/Example/IlluminatorUITests/IlluminatorUITests.swift
@@ -7,19 +7,38 @@
 //
 
 import XCTest
-import Illuminator
+@testable import Illuminator
 import IlluminatorBridge
 
-class IlluminatorUITests: XCTaggedTestCase {
+class IlluminatorUITests: XCTestCase, IlluminatorTestResultHandler {
+    
+    // implement IlluminatorTestResultHandler protocol
+    typealias AbstractStateType = AppTestState
+    func handleTestResult(isPass: Bool, isFail: Bool, state: AbstractStateType?, errorMessages: [String]) -> (){
+        // on failure, print out what was on the screen when things failed
+        if isFail {
+            for line in IlluminatorElement.accessorDump("app", appDebugDescription: app.debugDescription) {
+                print(line)
+            }
+        }
         
+        if isPass {
+            print("THE RESULT WAS A PASS! but generally we don't do anything for passing tests")
+        }
+    }
+    
+    var app: XCUIApplication!
+
+    
     override func setUp() {
         super.setUp()
         
         // Put setup code here. This method is called before the invocation of each test method in the class.
         
         // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-        XCUIApplication().launch()
-
+        app = XCUIApplication()
+        app.launch()
+        
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
     
@@ -30,7 +49,6 @@ class IlluminatorUITests: XCTaggedTestCase {
     
     func test_basicWithoutIlluminator() {
         
-        let app = XCUIApplication()
         let textField = app.otherElements.containingType(.Button, identifier:"Button").childrenMatchingType(.TextField).element
         
         textField.tap()
@@ -42,15 +60,28 @@ class IlluminatorUITests: XCTaggedTestCase {
     
     func test_basicWithIlluminator() {
         
-        let app = ExampleTestApp(testCase: self)
+        let interface = ExampleTestApp(testCase: self)
         let initialState = IlluminatorTestProgress<AppTestState>.Passing(AppTestState(didSomething: false))
         
         let myExampleText = "test123"
         
         initialState
-            .apply(app.home.enterText(myExampleText))
-            .apply(app.home.verifyText(myExampleText))
-        .finish()
+            .apply(interface.home.enterText(myExampleText))
+            .apply(interface.home.verifyText(myExampleText))
+            .finish()
+    }
+    
+    func test_basicWithIlluminatorAndHandler() {
+        
+        let interface = ExampleTestApp(testCase: self)
+        let initialState = IlluminatorTestProgress<AppTestState>.Passing(AppTestState(didSomething: false))
+        
+        let myExampleText = "test123"
+        
+        initialState
+            .apply(interface.home.enterText(myExampleText))
+            .apply(interface.home.verifyText(myExampleText))
+            .finish(self)
     }
     
 

--- a/Example/IlluminatorUITests/IlluminatorUITests.swift
+++ b/Example/IlluminatorUITests/IlluminatorUITests.swift
@@ -72,17 +72,30 @@ class IlluminatorUITests: XCTestCase, IlluminatorTestResultHandler {
             .finish()
     }
     
-    func test_basicWithIlluminatorAndHandler() {
-        
+    func test_basicWithIlluminatorAndHandlerProtocol() {
+
         let interface = ExampleTestApp(testCase: self)
         let initialState = IlluminatorTestProgress<AppTestState>.Passing(AppTestState(didSomething: false))
-        
+
         let myExampleText = "test123"
-        
+
         initialState
             .apply(interface.home.enterText(myExampleText))
             .apply(interface.home.verifyText(myExampleText))
             .finish(self)
+    }
+    
+    func test_basicWithIlluminatorAndHandlerClosure() {
+
+        let interface = ExampleTestApp(testCase: self)
+        let initialState = IlluminatorTestProgress<AppTestState>.Passing(AppTestState(didSomething: false))
+
+        let myExampleText = "test123"
+
+        initialState
+            .apply(interface.home.enterText(myExampleText))
+            .apply(interface.home.verifyText(myExampleText))
+            .finish(self.handleTestResult)
     }
     
 

--- a/Example/IlluminatorUITests/IlluminatorUITests.swift
+++ b/Example/IlluminatorUITests/IlluminatorUITests.swift
@@ -71,6 +71,18 @@ class IlluminatorUITests: XCTestCase, IlluminatorTestResultHandler {
             .apply(interface.home.verifyText(myExampleText))
             .finish()
     }
+
+    func test_basicWithIlluminatorCompositeAction() {
+
+        let interface = ExampleTestApp(testCase: self)
+        let initialState = IlluminatorTestProgress<AppTestState>.Passing(AppTestState(didSomething: false))
+
+        let myExampleText = "test123"
+
+        initialState
+            .apply(interface.home.enterAndVerifyText(myExampleText))
+            .finish(self)
+    }
     
     func test_basicWithIlluminatorAndHandlerProtocol() {
 

--- a/Pod/Illuminator/IlluminatorElement.swift
+++ b/Pod/Illuminator/IlluminatorElement.swift
@@ -289,9 +289,9 @@ class IlluminatorElement: Equatable {
     
     // return a list of copy-pastable accessors representing elements on the screen
     static func accessorDump(appVarname: String, appDebugDescription: String) -> [String] {
-        let parsedTree = IlluminatorElement.fromDebugDescription(appDebugDescription)
+        guard let parsedTree = IlluminatorElement.fromDebugDescription(appDebugDescription) else { return [] }
         
-        let lines = parsedTree!.reduce([String?]()) { (acc, elem) in
+        let lines = parsedTree.reduce([String?]()) { (acc, elem) in
             let str = elem.toXCUIElementString(appVarname)
             return str == nil ? acc : acc + [str]
         }

--- a/Pod/Illuminator/IlluminatorExceptions.swift
+++ b/Pod/Illuminator/IlluminatorExceptions.swift
@@ -14,6 +14,7 @@ public enum IlluminatorExceptions: ErrorType {
     case IncorrectScreen(message: String)     // we're on the wrong screen
     //case IndeterminateState(message: String)  // the saved state doesn't make sense
     //case VerificationFailed(message: String)  // we wanted something that wasn't there
+    case DeveloperError(message: String)      // the writer of the test is using Illuminator incorrectly
 }
 
 public protocol WaitForible: Equatable, CustomStringConvertible {}

--- a/Pod/Illuminator/IlluminatorScreen.swift
+++ b/Pod/Illuminator/IlluminatorScreen.swift
@@ -69,6 +69,26 @@ public class IlluminatorBaseScreen<T>: IlluminatorScreen {
             return state
         }
     }
+    
+    // shortcut function to make composite actions
+    public func makeAction(firstAction: IlluminatorActionGeneric<T>, secondAction: IlluminatorActionGeneric<T>, label l: String = #function) -> IlluminatorActionGeneric<T> {
+        return makeAction(label: l) { (state: T) in
+            return try secondAction.task(try firstAction.task(state))
+        }
+    }
+    
+    // shortcut function to make composite actions
+    public func makeAction(actions: [IlluminatorActionGeneric<T>], label l: String = #function) -> IlluminatorActionGeneric<T> {
+        // need 2 actions to do anything useful
+        guard actions.count > 0 else {
+            return makeAction() {
+                throw IlluminatorExceptions.DeveloperError(message: "Trying to make a composite Illuminator action from none")
+            }
+        }
+        guard actions.count > 1 else { return actions[0] }
+  
+        return actions.tail.reduce(actions[0]) { makeAction($0, secondAction: $1) }
+    }
 }
 
 // a "normal" screen -- one that may take a moment of animation to appear

--- a/Pod/Illuminator/IlluminatorTestProgress.swift
+++ b/Pod/Illuminator/IlluminatorTestProgress.swift
@@ -14,7 +14,7 @@ import XCTest
  * isPass and isFail can both be false -- it indicates a "Flagging" state.  They are guaranteed to not both be true
  */
 public protocol IlluminatorTestResultHandler {
-    typealias AbstractStateType
+    associatedtype AbstractStateType
     func handleTestResult(isPass: Bool, isFail: Bool, state: AbstractStateType?, errorMessages: [String]) -> ()
 }
 

--- a/Pod/Illuminator/IlluminatorTestProgress.swift
+++ b/Pod/Illuminator/IlluminatorTestProgress.swift
@@ -142,12 +142,12 @@ public enum IlluminatorTestProgress<T: CustomStringConvertible> {
 }
 
 // How to assert Illuminator test progress is pass
-public func XCTAssert<T>(progress: IlluminatorTestProgress<T>) {
+public func XCTAssert<T>(progress: IlluminatorTestProgress<T>, file f: StaticString = #file, line l: UInt = #line) {
     switch progress {
     case .Failing(_, let errStrings):
-        XCTAssert(false,  errStrings.joinWithSeparator("; "))
+        XCTFail("Illuminator Failure: \(errStrings.joinWithSeparator("; "))", file: f, line: l)
     case .Flagging(_, let errStrings):
-        XCTAssert(false,  errStrings.joinWithSeparator("; "))
+        XCTFail("Illuminator Deferred Failure: \(errStrings.joinWithSeparator("; "))", file: f, line: l)
     case .Passing:
         return
     }

--- a/Pod/Illuminator/IlluminatorTestProgress.swift
+++ b/Pod/Illuminator/IlluminatorTestProgress.swift
@@ -9,6 +9,42 @@
 import Foundation
 import XCTest
 
+/*
+ * This protocol allows custom handling of results.  For example, screenshots of failure states or desktop notifications
+ * isPass and isFail can both be false -- it indicates a "Flagging" state.  They are guaranteed to not both be true
+ */
+public protocol IlluminatorTestResultHandler {
+    typealias AbstractStateType
+    func handleTestResult(isPass: Bool, isFail: Bool, state: AbstractStateType?, errorMessages: [String]) -> ()
+}
+
+
+// cheap hack to get a generic protocol
+// https://milen.me/writings/swift-generic-protocols/
+struct IlluminatorTestResultHandlerThunk<T> : IlluminatorTestResultHandler {
+    typealias AbstractStateType = T
+    
+    // closure which will be used to implement `handleTestResult()` as declared in the protocol
+    private let _handleTestResult : (isPass: Bool, isFail: Bool, state: T?, errorMessages: [String]) -> ()
+    
+    // `T` is effectively a handle for `AbstractStateType` in the protocol
+    init<P : IlluminatorTestResultHandler where P.AbstractStateType == T>(_ dep : P) {
+        // requires Swift 2, otherwise create explicit closure
+        _handleTestResult = dep.handleTestResult
+    }
+    
+    func handleTestResult(isPass: Bool, isFail: Bool, state: AbstractStateType?, errorMessages: [String]) -> () {
+        // any protocol methods are implemented by forwarding
+        return _handleTestResult(isPass: isPass, isFail: isFail, state: state, errorMessages: errorMessages)
+    }
+}
+
+
+/*
+ * This enum uses some functional magic to apply a set of device actions to an initial (passing) state.
+ * Each action acts on the current state of the XCUIApplication() and a state variable that may optionally be passed to it
+ * Thus, each action is by itself stateless.
+ */
 @available(iOS 9.0, *)
 public enum IlluminatorTestProgress<T> {
     case Passing(T)
@@ -95,10 +131,20 @@ public enum IlluminatorTestProgress<T> {
         return applyAction(action, checkScreen: false)
     }
     
+    // handle the final result in terms of a test case
+    public func finish<P: IlluminatorTestResultHandler where P.AbstractStateType == T>(handler: P) {
+        let (isPassing, isFailing, state, errorMessages) = normalize()
+        
+        let genericHandler: IlluminatorTestResultHandlerThunk<T> = IlluminatorTestResultHandlerThunk(handler)
+        genericHandler.handleTestResult(isPassing, isFail: isFailing, state: state, errorMessages: errorMessages)
+        
+        // worst case, we handle it ourselves with a default implementation
+        finish()
+    }
+    
     // interpret the final result in terms of a test case
     public func finish() {
         let (isPassing, _, _, errorMessages) = normalize()
-        print(XCUIApplication().debugDescription)
         XCTAssert(isPassing, errorMessages.joinWithSeparator("; "))
     }
     

--- a/Pod/Illuminator/IlluminatorTestProgress.swift
+++ b/Pod/Illuminator/IlluminatorTestProgress.swift
@@ -125,7 +125,8 @@ public enum IlluminatorTestProgress<T: CustomStringConvertible> {
         return applyAction(action, checkScreen: false)
     }
     
-    // handle the final result in terms of a test case
+    // handle the final result using a protocol-conformant object
+    // then either pass or fail
     public func finish<P: IlluminatorTestResultHandler where P.AbstractStateType == T>(handler: P) {
         let genericHandler: IlluminatorTestResultHandlerThunk<T> = IlluminatorTestResultHandlerThunk(handler)
         genericHandler.handleTestResult(self)
@@ -133,8 +134,15 @@ public enum IlluminatorTestProgress<T: CustomStringConvertible> {
         // worst case, we handle it ourselves with a default implementation
         finish()
     }
+
+    // handle the final result using a passed-in closure 
+    // then either pass or fail
+    public func finish(handler: (IlluminatorTestProgress<T>) -> ()) {
+        handler(self)
+        finish()
+    }
     
-    // interpret the final result in terms of a test case
+    // interpret the final result in XCTest terms.  this will pass or fail
     public func finish() {
         XCTAssert(self)
     }


### PR DESCRIPTION
Implement a protocol, handle your own results. 

This allows a straightforward way to implement app-specific functionality in handling test passes or failures.  