### PR TITLE
Fix transient screen handling

### DIFF
--- a/Pod/Illuminator/IlluminatorScreen.swift
+++ b/Pod/Illuminator/IlluminatorScreen.swift
@@ -149,15 +149,12 @@ public class IlluminatorScreenWithTransient<T>: IlluminatorBaseScreen<T> {
     var nextTimeoutHard: Double
     
     
-    public init (testCaseWrapper: IlluminatorTestcaseWrapper,
-                 label: String,
-                 screenTimeoutSoft timeoutSoft: Double,
-                                   screenTimeoutHard timeoutHard: Double) {
+    public init (label labelVal: String, testCaseWrapper t: IlluminatorTestcaseWrapper,                                       screenTimeoutSoft timeoutSoft: Double, screenTimeoutHard timeoutHard: Double) {
         screenTimeoutSoft = timeoutSoft
         screenTimeoutHard = timeoutHard
         nextTimeoutSoft = screenTimeoutSoft
         nextTimeoutHard = screenTimeoutHard
-        super.init(label: label, testCaseWrapper: testCaseWrapper)
+        super.init(label: labelVal, testCaseWrapper: t)
     }
     
     // To be overridden by the extender of the class

--- a/Pod/Illuminator/extensions/XCUIElement.swift
+++ b/Pod/Illuminator/extensions/XCUIElement.swift
@@ -79,10 +79,19 @@ extension XCUIElement {
         return result
     }
 
-    func swipeTo(target element: XCUIElement, direction: UISwipeGestureRecognizerDirection, failMessage: String, giveUpCondition: (XCUIElement, XCUIElement) -> Bool) throws {
+    /**
+     Swipe until an element is revealed
+     @param target the element being searched for
+     @param direction the swipe direction (the reverse of the scroll direction)
+     @param failMessage Text to append to the failure message, indicating the exit condition
+     @param giveUpCondition Closure that returns true when the swipe operations should terminate
+     @return the target element
+     @throws IlluminatorExceptions.ElementNotReady If the target is not found
+     */
+    func swipeTo(target element: XCUIElement, direction: UISwipeGestureRecognizerDirection, failMessage: String, giveUpCondition: (XCUIElement, XCUIElement) -> Bool) throws -> XCUIElement  {
         repeat {
             if element.exists {
-                if element.hittable { return }
+                if element.hittable { return element }
             }
 
             switch direction {
@@ -102,18 +111,35 @@ extension XCUIElement {
         if !element.inMainWindow {
             throw IlluminatorExceptions.ElementNotReady(message: "Couldn't find \(element) after \(failMessage)")
         }
+        return element
     }
 
-    func swipeTo(target element: XCUIElement, direction: UISwipeGestureRecognizerDirection, withTimeout seconds: Double) throws {
+    /**
+     Swipe until an element is revealed or a timeout is reached
+     @param target the element being searched for
+     @param direction the swipe direction (the reverse of the scroll direction)
+     @param withTimeout the number of seconds to wait before failing
+     @return the target element
+     @throws IlluminatorExceptions.ElementNotReady If the target is not found
+     */
+    func swipeTo(target element: XCUIElement, direction: UISwipeGestureRecognizerDirection, withTimeout seconds: Double) throws -> XCUIElement {
         let startTime = NSDate()
-        try swipeTo(target: element, direction: direction, failMessage: "scrolling for \(seconds) seconds") { (_, _) in
+        return try swipeTo(target: element, direction: direction, failMessage: "scrolling for \(seconds) seconds") { (_, _) in
             return (0 - startTime.timeIntervalSinceNow) > seconds
         }
     }
 
-    func swipeTo(target element: XCUIElement, direction: UISwipeGestureRecognizerDirection, maxSwipes: UInt) throws {
+    /**
+     Swipe until an element is revealed or a timeout is reached
+     @param target the element being searched for
+     @param direction the swipe direction (the reverse of the scroll direction)
+     @param maxSwipes the number of times to swipe before failing
+     @return the target element
+     @throws IlluminatorExceptions.ElementNotReady If the target is not found
+     */
+    func swipeTo(target element: XCUIElement, direction: UISwipeGestureRecognizerDirection, maxSwipes: UInt) throws -> XCUIElement {
         var totalSwipes: UInt = 0
-        try swipeTo(target: element, direction: direction, failMessage: "swiping \(maxSwipes) times") { (_, _) in
+        return try swipeTo(target: element, direction: direction, failMessage: "swiping \(maxSwipes) times") { (_, _) in
             totalSwipes = totalSwipes + 1
             return totalSwipes > maxSwipes
         }

--- a/Pod/Illuminator/extensions/XCUIElement.swift
+++ b/Pod/Illuminator/extensions/XCUIElement.swift
@@ -208,10 +208,34 @@ extension XCUIElement {
         return try whenReady(usingCriteria: defaultReadiness, withTimeout: secondsToWait)
     }
 
-    public func waitForProperty<T: WaitForible>(seconds: Double, desired: T, getProperty: (XCUIElement) -> T) throws {
+    /**
+     Wait until an element property reaches a specific value or a timeout is reached
+     @param seconds the time to wait
+     @param desired the desired value
+     @param getProperty a closure that returns the property, given the element
+     @return the element
+     @throws IlluminatorExceptions.VerificationFailed If the property fails to attains the value
+     */
+    public func waitForProperty<T: WaitForible>(seconds: Double, desired: T, getProperty: (XCUIElement) -> T) throws -> XCUIElement {
         try waitForResult(seconds, desired: desired, what: "waitForProperty") { () -> T in
             return getProperty(self)
         }
+        return self
+    }
+
+    /**
+     Assert an element property
+     @param desired the desired value
+     @param getProperty a closure that returns the property, given the element
+     @return the element
+     @throws IlluminatorExceptions.VerificationFailed If the property fails to attains the value
+     */
+    public func assertProperty<T: WaitForible>(desired: T, getProperty: (XCUIElement) -> T) throws -> XCUIElement {
+        let actual = getProperty(self)
+        if desired != actual {
+            throw IlluminatorExceptions.VerificationFailed(message: "Expected property to be '\(desired)', got '\(actual)'")
+         }
+        return self
     }
 }
 


### PR DESCRIPTION
* Fix a bug in timeout calculation of IlluminatorScreenWithTransient
* Rewrite transient-detection logic using `waitForResult` so that hierarchy changes are discovered
* Make `swipeTo` return the target element
* comment `swipeTo` family of functions